### PR TITLE
fix: 🐛 update diff excludes in Chezmoi config to skip dirs

### DIFF
--- a/home/.chezmoi.yaml.tmpl
+++ b/home/.chezmoi.yaml.tmpl
@@ -142,6 +142,7 @@ diff:
   args: "--side-by-side"
   exclude:
     - scripts
+    - dirs
 env:
 {{- if eq .chezmoi.os "darwin" }}
   {{- if eq .chezmoi.arch "arm64" }}


### PR DESCRIPTION
Fixes #21