### PR TITLE
Feature/migrate secrets to hcp cli

### DIFF
--- a/home/.chezmoi.yaml.tmpl
+++ b/home/.chezmoi.yaml.tmpl
@@ -12,7 +12,7 @@ SPDX-License-Identifier: MIT
 {{- $state := dict "persistent" false "ephemeral" false -}}
 {{- $secrets := dict "apikeys" false "sshkeys" false "storagekeys" false -}}
 {{- $git := dict -}}
-{{- $hcp := dict -}}
+{{- $vlt := dict -}}
 
 {{/* Test if the user is in a container by checking that a TTY is not present */}}
 {{- if not stdinIsATTY -}}
@@ -154,26 +154,25 @@ env:
   BREW_PATH: "/home/linuxbrew/.linuxbrew/bin/brew"
 {{- end }}
 {{- if or $secrets.apikeys $secrets.sshkeys $secrets.storagekeys }}
-  {{- $_ := set $hcp "clientID" (promptStringOnce $hcp "clientID" "What is your Vault Secrets Service Principal ID") }}
-  {{- $_ := set $hcp "clientSecret" (promptStringOnce $hcp "clientSecret" "What is your Vault Secrets Service Principal Secret") }}
-  HCP_CLIENT_ID: {{ $hcp.clientID | quote }}
-  HCP_CLIENT_SECRET: {{ $hcp.clientSecret | quote }}
+  {{- $_ := set $vlt "clientID" (promptStringOnce $vlt "clientID" "What is your Vault Secrets Service Principal ID") }}
+  {{- $_ := set $vlt "clientSecret" (promptStringOnce $vlt "clientSecret" "What is your Vault Secrets Service Principal Secret") }}
+  HCP_CLIENT_ID: {{ $vlt.clientID | quote }}
+  HCP_CLIENT_SECRET: {{ $vlt.clientSecret | quote }}
 encryption: age
 age:
   identity: "{{ $.chezmoi.homeDir }}/.config/age/key.txt"
   recipient: "age183zmhhlz4wg0a8qmweyzmm5cf0y0g4tyulxg8ldjzjmkgze2sqlsnvwuqs"
-hcpVaultSecrets:
-  {{- $_ := set $hcp "orgID" (promptStringOnce $hcp "orgID" "What is your Vault Secrets Organisation ID") }}
-  {{- $_ := set $hcp "projectID" (promptStringOnce $hcp "projectID" "What is your Vault Secrets Project ID") }}
-  organizationId: {{ $hcp.orgID | quote }}
-  projectId: {{ $hcp.projectID | quote }}
-  applicationName: chezmoi
 hooks:
   read-source-state:
     pre:
-      command: ".local/share/chezmoi/home/.hooks/.install-hcp-vlt.sh"
+      command: ".local/share/chezmoi/home/.hooks/.install-hcp-cli.sh"
 {{- end }}
 data:
+{{- if or $secrets.apikeys $secrets.sshkeys $secrets.storagekeys }}
+  hcp:
+    {{- $_ := set $vlt "appName" (promptStringOnce $vlt "appName" "What is your HCP Vault Secrets application name") }}
+    appName: {{ $vlt.appName | quote }}
+{{- end }}
   target:
     {{- range $key, $value := $target }}
     {{ $key }}: {{ $value }}

--- a/home/.chezmoitemplates/universal/hcpHandler.tmpl
+++ b/home/.chezmoitemplates/universal/hcpHandler.tmpl
@@ -1,0 +1,14 @@
+{{/*
+SPDX-FileCopyrightText: (c) 2024 Rowan Gillson <devops@the.bald.engineer>
+SPDX-License-Identifier: MIT
+*/}}
+
+{{/*
+  * Function to get the static version of the secrets from HCP Vault
+  *
+  * Required arguments (in order):
+  * 1. The HCP Vault Secrets application name, as defined in Chezmoi data .hcp.appName
+  * 2. The secret name, as defined in an HCP Vault Secrets application config
+  *
+*/}}
+{{- (output "hcp" "vault-secrets" "secrets" "open" "--format" "json" "--app" (index . 0) (index . 1) | fromJson).static_version.value -}}

--- a/home/.chezmoitemplates/universal/packages.def
+++ b/home/.chezmoitemplates/universal/packages.def
@@ -25,7 +25,7 @@ SPDX-License-Identifier: MIT
   "yq"
   "zellij"
   "zsh"
-  "hashicorp/tap/vlt"
+  "hashicorp/tap/hcp"
   "olets/tap/zsh-abbr"
 -}}
 {{- $packages | sortAlpha | join " " -}}

--- a/home/.hooks/.install-hcp-cli.sh
+++ b/home/.hooks/.install-hcp-cli.sh
@@ -53,25 +53,25 @@ fetch_jq_binary() {
   check_binary_installed "jq" || fetch_binary "jq" "$jq_download_url"
 }
 
-# Fetch vlt binary
-fetch_vlt_binary() {
-  local vlt_system_os
-  local vlt_system_arch
-  local vlt_download_url
-  vlt_system_os=$(uname -s | tr '[:upper:]' '[:lower:]')
-  vlt_system_arch=$(uname -m | tr '[:upper:]' '[:lower:]' | sed 's/x86_64/amd64/g') # we need to replace the output of uname -m to match the vlt binary naming convention
-  vlt_download_url=$(curl -s https://releases.hashicorp.com/vlt/index.json | jq -r --arg os "$vlt_system_os" --arg arch "$vlt_system_arch" '.versions | to_entries | map(select(.key | test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))) | map(.value.builds[] | select(.os == $os and .arch == $arch)) | sort_by(.version) | last | .url') || exit 1
+# Fetch hcp binary
+fetch_hcp_binary() {
+  local hcp_system_os
+  local hcp_system_arch
+  local hcp_download_url
+  hcp_system_os=$(uname -s | tr '[:upper:]' '[:lower:]')
+  hcp_system_arch=$(uname -m | tr '[:upper:]' '[:lower:]' | sed 's/x86_64/amd64/g') # we need to replace the output of uname -m to match the hcp binary naming convention
+  hcp_download_url=$(curl -s https://releases.hashicorp.com/hcp/index.json | jq -r --arg os "$hcp_system_os" --arg arch "$hcp_system_arch" '.versions | to_entries | max_by(.key) | .value.builds[] | select(.arch == $arch and .os == $os) | .url') || exit 1
 
   check_binary_installed "python3" || {
     exit 1
   }
 
-  # Check if vlt is already installed and skip if found, otherwise install it
-  if check_binary_installed "vlt"; then
+  # Check if hcp is already installed and skip if found, otherwise install it
+  if check_binary_installed "hcp"; then
     return 0
   else
-    fetch_binary "vlt.zip" "$vlt_download_url"
-    python3 -c "import zipfile, os; zipfile.ZipFile('${bin_directory}/vlt.zip').extractall('${bin_directory}'); os.chmod('${bin_directory}/vlt', 0o755); os.remove('${bin_directory}/vlt.zip')" || {
+    fetch_binary "hcp.zip" "$hcp_download_url"
+    python3 -c "import zipfile, os; zipfile.ZipFile('${bin_directory}/hcp.zip').extractall('${bin_directory}'); os.chmod('${bin_directory}/hcp', 0o755); os.remove('${bin_directory}/hcp.zip')" || {
       exit 1
     }
   fi
@@ -80,7 +80,7 @@ fetch_vlt_binary() {
 main() {
   setup_bin_directory
   fetch_jq_binary
-  fetch_vlt_binary
+  fetch_hcp_binary
 }
 
 main "$@"

--- a/home/dot_config/exact_git/user.tmpl
+++ b/home/dot_config/exact_git/user.tmpl
@@ -1,8 +1,12 @@
-{{ if and .function.personal .target.darwin -}}
+{{/*
+SPDX-FileCopyrightText: (c) 2024 Rowan Gillson <devops@the.bald.engineer>
+SPDX-License-Identifier: MIT
+*/}}
+{{- if and .function.personal .target.darwin -}}
 [user]
   name = {{ .git.name }}
   email = {{ .git.email }}
-  signingkey = {{ hcpVaultSecret "sshSigningKeyPersonal" }}
+  signingkey = {{ includeTemplate "universal/hcpHandler.tmpl" (list .hcp.appName "sshSigningKeyPersonal") | trim }}
 
 [gpg]
   format = ssh
@@ -29,7 +33,7 @@
 [user]
   name = {{ .git.name }}
   email = {{ .git.email }}
-  signingkey = {{ hcpVaultSecret "sshSigningKeyWork" }}
+  signingkey = {{ includeTemplate "universal/hcpHandler.tmpl" (list .hcp.appName "sshSigningKeyWork") | trim }}
 
 [gpg]
   format = ssh

--- a/home/dot_config/private_rclone/private_rclone.conf.tmpl
+++ b/home/dot_config/private_rclone/private_rclone.conf.tmpl
@@ -1,10 +1,14 @@
+{{/*
+SPDX-FileCopyrightText: (c) 2024 Rowan Gillson <devops@the.bald.engineer>
+SPDX-License-Identifier: MIT
+*/}}
 [GDrive]
 type = drive
-client_id = {{ hcpVaultSecret "rcloneDriveId" -}}
-client_secret = {{ hcpVaultSecret "rcloneDriveSecret" -}}
+client_id = {{ includeTemplate "universal/hcpHandler.tmpl" (list .hcp.appName "rcloneDriveId") | trim }}
+client_secret = {{ includeTemplate "universal/hcpHandler.tmpl" (list .hcp.appName "rcloneDriveSecret") | trim }}
 scope = drive.file
-token = {{ hcpVaultSecret "rcloneDriveToken" -}}
-root_folder_id = {{ hcpVaultSecret "rcloneDriveRootDir" -}}
+token = {{ includeTemplate "universal/hcpHandler.tmpl" (list .hcp.appName "rcloneDriveToken") | trim }}
+root_folder_id = {{ includeTemplate "universal/hcpHandler.tmpl" (list .hcp.appName "rcloneDriveRootDir") | trim }}
 use_trash = false
 chunk_size = 32M
 skip_gdocs = true
@@ -16,5 +20,5 @@ skip_dangling_shortcuts = true
 [GDCrypt]
 type = crypt
 remote = GDrive:
-password = {{ hcpVaultSecret "rcloneDriveEncryptKey" -}}
-password2 = {{ hcpVaultSecret "rcloneDriveEncryptSalt" -}}
+password = {{ includeTemplate "universal/hcpHandler.tmpl" (list .hcp.appName "rcloneDriveEncryptKey") | trim }}
+password2 = {{ includeTemplate "universal/hcpHandler.tmpl" (list .hcp.appName "rcloneDriveEncryptSalt") | trim }}

--- a/home/dot_config/wakatime/private_dot_wakatime.cfg.tmpl
+++ b/home/dot_config/wakatime/private_dot_wakatime.cfg.tmpl
@@ -1,3 +1,6 @@
-
+{{/*
+SPDX-FileCopyrightText: (c) 2024 Rowan Gillson <devops@the.bald.engineer>
+SPDX-License-Identifier: MIT
+*/}}
 [settings]
-api_key = {{ hcpVaultSecret "wakatimeApiKeyGlobal" }}
+api_key = {{ includeTemplate "universal/hcpHandler.tmpl" (list .hcp.appName "wakatimeApiKeyGlobal") | trim }}

--- a/home/private_dot_ssh/allowed_signers.tmpl
+++ b/home/private_dot_ssh/allowed_signers.tmpl
@@ -1,6 +1,6 @@
 {{ if and .function.personal .target.darwin -}}
-  {{ .git.email }} namespaces="git" {{ hcpVaultSecret "sshSigningKeyPersonal" }}
+  {{ .git.email }} namespaces="git" {{ includeTemplate "universal/hcpHandler.tmpl" (list .hcp.appName "sshSigningKeyPersonal") | trim }}
 {{- end -}}
 {{- if and .function.work .target.wsl -}}
-  {{ .git.email }} namespaces="git" {{ hcpVaultSecret "sshSigningKeyWork" }}
+  {{ .git.email }} namespaces="git" {{ includeTemplate "universal/hcpHandler.tmpl" (list .hcp.appName "sshSigningKeyPersonal") | trim }}
 {{- end -}}

--- a/home/private_dot_ssh/authorized_keys.tmpl
+++ b/home/private_dot_ssh/authorized_keys.tmpl
@@ -1,2 +1,2 @@
-{{ hcpVaultSecret "sshAuthKeyWork" -}} Work SSH Auth Key
-{{ hcpVaultSecret "sshSigningKeyWork" -}} Work SSH Signing Key
+{{ includeTemplate "universal/hcpHandler.tmpl" (list .hcp.appName "sshAuthKeyWork") | trim }} Work SSH Auth Key
+{{ includeTemplate "universal/hcpHandler.tmpl" (list .hcp.appName "sshSigningKeyWork") | trim }} Work SSH Signing Key

--- a/home/private_dot_ssh/private_keys.d/id_ed25519.auth.work.pub.tmpl
+++ b/home/private_dot_ssh/private_keys.d/id_ed25519.auth.work.pub.tmpl
@@ -1,1 +1,1 @@
-{{ hcpVaultSecret "sshAuthKeyWork" -}} Work SSH Auth Key
+{{- includeTemplate "universal/hcpHandler.tmpl" (list .hcp.appName "sshAuthKeyWork") }} Work SSH Auth Key

--- a/home/private_dot_ssh/private_keys.d/id_ed25519.sign.work.pub.tmpl
+++ b/home/private_dot_ssh/private_keys.d/id_ed25519.sign.work.pub.tmpl
@@ -1,1 +1,1 @@
-{{ hcpVaultSecret "sshSigningKeyWork" -}} Work SSH Signing Key
+{{- includeTemplate "universal/hcpHandler.tmpl" (list .hcp.appName "sshSigningKeyWork") }} Work SSH Signing Key


### PR DESCRIPTION
- Replaced pre-installation hook script to fetch and make `hcp` available instead of `vlt` for retrieving secrets
- Updated Chezmoi data to prompt for HCP Vault Secrets app name containing relevant dotfiles secrets
- Created a helper function to retrieve secrets
- Migrated all secret config to use new helper function