### PR TITLE
fix(wsl): properly brace shell variables to correct type as integer

### DIFF
--- a/home/dot_config/zsh/dot_zshrc.tmpl
+++ b/home/dot_config/zsh/dot_zshrc.tmpl
@@ -226,9 +226,9 @@ fi
 
 {{ if .target.wsl -}}
 # Check for SSH_AUTH_SOCK env variable and load ssh-agent and SSH private key for Git commit signing
-if [ -z "$SSH_AUTH_SOCK" ]; then
+if [ -z "${SSH_AUTH_SOCK}" ]; then
   RUNNING_AGENT_COUNT=$(pgrep -cfx 'ssh-agent -s')
-  if [ "RUNNING_AGENT_COUNT" -eq 0 ]; then
+  if [ "${RUNNING_AGENT_COUNT}" -eq 0 ]; then
     ssh-agent -s > "${HOME}/.ssh/agent.env"
   fi
   eval $(cat "${HOME}/.ssh/agent.env") > /dev/null


### PR DESCRIPTION
Fixes #60 