### PR TITLE
chore: remove unused taps from brews.def and config Helix for editorconfig support

### DIFF
--- a/home/.chezmoitemplates/darwin/brews.def
+++ b/home/.chezmoitemplates/darwin/brews.def
@@ -5,7 +5,6 @@ SPDX-License-Identifier: MIT
 
 {{- $packages := splitList " " (includeTemplate "universal/brews.def" .) }}
 {{- $taps := list
-  "hashicorp/tap"
   "homebrew/bundle"
   "olets/tap"
 -}}
@@ -34,7 +33,6 @@ SPDX-License-Identifier: MIT
   "1password-cli"
   "antinote"
   "arc"
-  "brave-browser"
   "cleanshot"
   "discord"
   "firefox"

--- a/home/.chezmoitemplates/linux/controlled/brews.def
+++ b/home/.chezmoitemplates/linux/controlled/brews.def
@@ -5,7 +5,6 @@ SPDX-License-Identifier: MIT
 
 {{- $packages := splitList " " (includeTemplate "universal/brews.def" .) }}
 {{- $taps := list
-  "hashicorp/tap"
   "homebrew/bundle"
   "olets/tap"
 -}}

--- a/home/dot_config/helix/config.toml
+++ b/home/dot_config/helix/config.toml
@@ -1,5 +1,9 @@
 theme = "rose_pine"
 
 [editor]
-insert-final-newline = true
 mouse = false
+editor-config = true
+
+[editor.soft-wrap]
+enable = true
+wrap-at-text-width = true


### PR DESCRIPTION
This pull request introduces updates to configuration files for both macOS and Linux environments, as well as enhancements to the Helix editor configuration. The most notable changes involve the removal of specific taps and packages from Homebrew configuration templates and the addition of new editor settings for improved usability.

### Homebrew configuration updates:

* Removed the `hashicorp/tap` tap from both `darwin/brews.def` and `linux/controlled/brews.def` templates, streamlining the list of taps.

### Helix editor configuration enhancements:

* Added new editor settings in `config.toml`, including enabling `editor-config` and soft wrapping with options to wrap at text width. These changes aim to improve text editing flexibility.