### PR TITLE
chore: update Renovate configuration to use arrrgi-labs org presets

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,19 +1,8 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": [
-		"github>arrrgi/renovate-config:default",
-		"github>arrrgi/renovate-config:regexManager",
-		"helpers:pinGitHubActionDigests"
-	],
-	"enabledManagers": ["devcontainer", "github-actions", "pep621", "pyenv"],
-	"packageRules": [
-		{
-			"matchManagers": ["devcontainer", "github-actions", "pep621", "pyenv"],
-			"matchPackageNames": ["python"],
-			"groupName": "Python grouped version updates"
-		}
-	],
-	"constraints": {
-		"python": "3.13"
-	}
+		"github>arrrgi-labs/renovate-config",
+		"github>arrrgi-labs/renovate-config//presets/regexManager",
+		"github>arrrgi-labs/renovate-config//presets/groupPython"
+	]
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches Renovate to the shared arrrgi-labs presets to simplify maintenance and align with org standards. Replaces local managers, rules, and Python constraints with org defaults, including regexManager and grouped Python updates.

<sup>Written for commit a5d92d77fc2b1f6ed526aade581fc7319bb36cfa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

