### PR TITLE
chore: restrict Renovate managed Python version updates to 3.13.x

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,17 @@
 {
-	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": [
-		"github>arrrgi-labs/renovate-config",
-		"github>arrrgi-labs/renovate-config//presets/regexManager",
-		"github>arrrgi-labs/renovate-config//presets/groupPython"
-	]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>arrrgi-labs/renovate-config",
+    "github>arrrgi-labs/renovate-config//presets/regexManager",
+    "github>arrrgi-labs/renovate-config//presets/groupPython"
+  ],
+  "packageRules": [
+    // Define project package rule to restrict Python version updates to 3.13.x
+    {
+      "matchPackageNames": [
+        "**/python"
+      ],
+      "allowedVersions": ">=3.13 <3.14"
+    }
+  ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restricts Renovate-managed Python version updates to 3.13.x. Prevents auto-bumps to 3.14+ until we verify compatibility.

Added a package rule in .github/renovate.json matching "**/python" with allowedVersions ">=3.13 <3.14".

<sup>Written for commit 9dc037a1404203730f90652c5527e6a03dcca9ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

