### PR TITLE
fix: update Python package matching regex in Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,10 +6,9 @@
     "github>arrrgi-labs/renovate-config//presets/groupPython"
   ],
   "packageRules": [
-    // Define project package rule to restrict Python version updates to 3.13.x
     {
       "matchPackageNames": [
-        "**/python"
+        "/(^|\\/)python$/"
       ],
       "allowedVersions": ">=3.13 <3.14"
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix Renovate config to correctly match the Python package using a path-segment regex. This prevents false positives and ensures updates stay within 3.13.x.

<sup>Written for commit 562d61f06314e160adc4891f298993ac421c540e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

