### PR TITLE
fix: simplify match pattern for python updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,7 @@
   "packageRules": [
     {
       "matchPackageNames": [
-        "/(^|\\/)python$/"
+        "python"
       ],
       "allowedVersions": ">=3.13 <3.14"
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Simplified Renovate config by matching the Python package by name instead of a regex, keeping updates limited to versions >=3.13 and <3.14 for clearer, reliable matching.

<sup>Written for commit d41189f1f82c1aee34864f1fdbc8dfbeeb3e67a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

