### PR TITLE
refactor: use regex and glob constraint and matching for Python version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,15 +2,23 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>arrrgi-labs/renovate-config",
-    "github>arrrgi-labs/renovate-config//presets/regexManager",
-    "github>arrrgi-labs/renovate-config//presets/groupPython"
+    "github>arrrgi-labs/renovate-config//presets/regexManager"
   ],
   "packageRules": [
     {
-      "matchPackageNames": [
-        "python"
+      "description": "Constrain Python to 3.13.x and reinforce grouping across all managers",
+      "matchManagers": [
+        "devcontainer",
+        "github-actions",
+        "pep621",
+        "pyenv"
       ],
-      "allowedVersions": ">=3.13 <3.14"
+      "matchPackageNames": [
+        "**/python"
+      ],
+      "allowedVersions": "/^3\\.13\\./",
+      "groupName": "Project Python version",
+      "groupSlug": "project-python-version"
     }
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored Renovate config to enforce Python 3.13.x across all managers using regex and glob matching. All Python updates are now grouped under a single PR.

- **Refactors**
  - Replaced version range with regex /^3\.13\./ and matched "**/python".
  - Applied to devcontainer, GitHub Actions, PEP 621, and pyenv; added a "Project Python version" group; removed the groupPython preset.

<sup>Written for commit ea9017930d69c7371e3fbc8a1a66e471c7fd35a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

